### PR TITLE
Futureproof Item type

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,12 +1,16 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { defineString } from 'firebase-functions/params';
-import { getAccessToken, search as spotifySearch, getEpisodes } from './spotify';
-import { mapToSearchResults } from './mapToSearchResults';
+import { getAccessToken, search as spotifySearch, getItems } from './spotify';
+import { mapToSearchResults, mapToItemMetadata } from './mapping';
+import { itemTypes } from '../../src/lib/types/ItemType';
+import type ItemType from '../../src/lib/types/ItemType';
+import type { SpotifyItemType } from './types/spotify';
 
 const SPOTIFY_CLIENT_ID = defineString('SPOTIFY_CLIENT_ID');
 const SPOTIFY_CLIENT_SECRET = defineString('SPOTIFY_CLIENT_SECRET');
 
 const MINIMUM_SEARCH_QUERY_LENGTH = 3;
+const MAXIMUM_METADATA_ITEM_IDS = 50;
 
 export const search = onCall({ enforceAppCheck: true, region: 'europe-west1' }, async (request) => {
 	if (!request.auth) {
@@ -29,7 +33,44 @@ export const search = onCall({ enforceAppCheck: true, region: 'europe-west1' }, 
 
 	const spotifySearchResponse = await spotifySearch(searchQuery, accessToken);
 	const episodeIds = spotifySearchResponse.episodes.items.map((item) => item.id);
-	const spotifyEpisodesResponse = await getEpisodes(episodeIds, accessToken);
+	const spotifyEpisodesResponse = await getItems('episodes', episodeIds, accessToken);
 
 	return mapToSearchResults(spotifySearchResponse, spotifyEpisodesResponse);
 });
+
+export const getSpotifyMetadata = onCall(
+	{ enforceAppCheck: true, region: 'europe-west1' },
+	async (request) => {
+		if (!request.auth) {
+			throw new HttpsError('unauthenticated', 'Must be authenticated.');
+		}
+
+		const itemType = request.data.itemType as ItemType;
+		const prefixlessItemIds = request.data.prefixlessItemIds;
+
+		if (typeof itemType !== 'string' || !itemTypes.includes(itemType)) {
+			throw new HttpsError(
+				'invalid-argument',
+				`Must be called with a string argument 'itemType' set to a valid item type.`
+			);
+		}
+
+		if (!Array.isArray(prefixlessItemIds) || prefixlessItemIds.length > MAXIMUM_METADATA_ITEM_IDS) {
+			throw new HttpsError(
+				'invalid-argument',
+				`Must be called with a string array argument 'prefixlessItemIds' with at most ${MAXIMUM_METADATA_ITEM_IDS} IDs.`
+			);
+		}
+
+		const accessToken = await getAccessToken(
+			SPOTIFY_CLIENT_ID.value(),
+			SPOTIFY_CLIENT_SECRET.value()
+		);
+
+		const spotifyItemType = (itemType === 'podcast' ? 'shows' : itemType + 's') as SpotifyItemType;
+
+		const spotifyResponse = await getItems(spotifyItemType, prefixlessItemIds, accessToken);
+
+		return mapToItemMetadata(itemType, spotifyResponse);
+	}
+);

--- a/functions/src/spotify.ts
+++ b/functions/src/spotify.ts
@@ -2,7 +2,7 @@ import { debug } from 'firebase-functions/logger';
 import { Agent } from 'https';
 import * as needle from 'needle';
 import { addSeconds, differenceInMinutes } from 'date-fns';
-import type { SearchResponse } from './types/spotify';
+import type { SearchResponse, SpotifyItemType } from './types/spotify';
 
 const agent = new Agent({ keepAlive: true });
 let cachedAccessToken: { accessToken: string; expiresAt: Date };
@@ -80,14 +80,18 @@ export const search = async (searchQuery: string, accessToken: string): Promise<
 	return response.body;
 };
 
-export const getEpisodes = async (episodeIds: string[], accessToken: string) => {
-	const episodeIdsCommaSeparated = episodeIds.join(',');
+export const getItems = async (
+	spotifyItemType: SpotifyItemType,
+	itemIds: string[],
+	accessToken: string
+) => {
+	const itemIdsCommaSeparated = itemIds.join(',');
 
 	const response = await needle(
 		'get',
-		`https://api.spotify.com/v1/episodes`,
+		`https://api.spotify.com/v1/${spotifyItemType}`,
 		{
-			ids: episodeIdsCommaSeparated,
+			ids: itemIdsCommaSeparated,
 			market: 'GB'
 		},
 		{
@@ -102,7 +106,7 @@ export const getEpisodes = async (episodeIds: string[], accessToken: string) => 
 		throw new Error(
 			`Unexpected ${
 				response.statusCode
-			} response from Spotify for episodes lookup ${episodeIdsCommaSeparated}: ${JSON.stringify(
+			} response from Spotify for ${spotifyItemType} lookup ${itemIdsCommaSeparated}: ${JSON.stringify(
 				response.body
 			)}`
 		);

--- a/functions/src/types/spotify.d.ts
+++ b/functions/src/types/spotify.d.ts
@@ -1,3 +1,5 @@
+export type SpotifyItemType = 'albums' | 'artists' | 'episodes' | 'shows' | 'tracks';
+
 export type SearchResponse = {
 	readonly albums: SearchResponseData<Album>;
 	readonly artists: SearchResponseData<Artist>;

--- a/src/lib/components/ItemBase.svelte
+++ b/src/lib/components/ItemBase.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { loading } from '$lib/stores/loading';
+	import { items } from '$lib/stores/items';
+	import { formatDistanceToNow } from 'date-fns';
+	import { prefersReducedMotion } from '$lib/stores/prefersReducedMotion';
+	import {
+		AccordionItem,
+		SlideToggle,
+		type ModalComponent,
+		type ModalSettings,
+		modalStore
+	} from '@skeletonlabs/skeleton';
+	import TrashBin from './icons/trash-bin.svelte';
+	import DeleteModal from './DeleteModal.svelte';
+	import type Item from '$lib/types/Item';
+
+	export let item: Item;
+	export let openAccordionItemId: string | null;
+
+	const onItemListenedChange = async (event: Event, item: Item) => {
+		if ($loading) {
+			event.preventDefault();
+			return;
+		}
+
+		await loading.whileAwaiting(() =>
+			items.upsertItem({
+				...item,
+				listened: (event.target as HTMLInputElement).checked
+			})
+		);
+	};
+
+	const deleteItem = (item: Item) => {
+		const modalComponent: ModalComponent = {
+			ref: DeleteModal,
+			props: { item }
+		};
+
+		const modal: ModalSettings = {
+			type: 'component',
+			component: modalComponent
+		};
+
+		modalStore.trigger(modal);
+	};
+</script>
+
+<AccordionItem
+	open={openAccordionItemId === item.id}
+	duration={$prefersReducedMotion ? 0 : undefined}
+	disabled={$loading}
+	on:toggle={(event) => {
+		goto(`/list${event.detail.open ? `?itemId=${item.id}` : ''}`, {
+			noScroll: true,
+			replaceState: true,
+			keepFocus: true
+		});
+	}}
+	regionControl="focus:-outline-offset-4"
+>
+	<div slot="lead" class="select-none">
+		<div class="flex flex-col gap-4 shrink-0 justify-center items-center">
+			<slot name="lead" />
+		</div>
+	</div>
+	<!-- Ignoring as the click event is only handled to prevent default -->
+	<!-- svelte-ignore a11y-click-events-have-key-events -->
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
+	<div
+		slot="summary"
+		class="flex flex-col select-text"
+		on:click={(event) => {
+			if (getSelection()?.toString()) {
+				event.preventDefault();
+				event.stopImmediatePropagation();
+				return;
+			}
+		}}
+	>
+		<span class="font-semibold">
+			{item.name}
+		</span>
+		<slot name="metadata" />
+	</div>
+	<div slot="content" class="flex flex-col gap-4 items-center">
+		<slot name="openButton" />
+		<SlideToggle
+			name={`listened-${item.id}`}
+			on:change={(event) => onItemListenedChange(event, item)}
+			checked={item.listened}
+			disabled={$loading}
+			class="focus:outline-offset-4"
+		>
+			Listened
+		</SlideToggle>
+		<small data-added-at-utc={item.addedAtUtc} class="text-center">
+			Added {formatDistanceToNow(new Date(item.addedAtUtc), { addSuffix: true })}
+			({new Date(item.addedAtUtc).toLocaleString()})
+		</small>
+		<button
+			class="btn-icon btn-icon-sm variant-filled-error"
+			disabled={$loading}
+			on:click={() => deleteItem(item)}
+		>
+			<TrashBin classes="w-4 h-4" />
+			<span class="sr-only">Delete {item.name}</span>
+		</button>
+	</div>
+</AccordionItem>

--- a/src/lib/components/ItemSpotify.svelte
+++ b/src/lib/components/ItemSpotify.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { loading } from '$lib/stores/loading';
+	import { spotifyItemMetadata } from '$lib/stores/spotifyItemMetadata';
+	import getPrefixlessId from '$lib/helpers/getPrefixlessId';
+	import ItemBase from './ItemBase.svelte';
+	import Headphone from './icons/headphone.svelte';
+	import SpotifyLogo from './SpotifyLogo.svelte';
+	import preventDefaultIf from '$lib/helpers/preventDefaultIf';
+	import SpotifyIcon from './SpotifyIcon.svelte';
+	import type Item from '$lib/types/Item';
+
+	export let item: Item;
+	export let openAccordionItemId: string | null;
+
+	$: itemMetadata = $spotifyItemMetadata[getPrefixlessId(item)];
+</script>
+
+<ItemBase {item} {openAccordionItemId}>
+	<svelte:fragment slot="lead">
+		{#if itemMetadata === undefined}
+			<div class="placeholder animate-pulse h-16 w-16" />
+		{:else if itemMetadata?.imageUrl}
+			<img class="h-16 w-16" src={itemMetadata.imageUrl} alt="" loading="lazy" />
+		{:else}
+			<div class="h-16 w-16 bg-surface-500 flex justify-center items-center">
+				<Headphone classes="h-6 w-6 text-white" />
+			</div>
+		{/if}
+		<SpotifyLogo classes="w-20" />
+	</svelte:fragment>
+	<svelte:fragment slot="metadata">
+		{#if !itemMetadata}
+			<span class="capitalize">{item.type}</span>
+			{#if ['album', 'podcast', 'track'].includes(item.type)}
+				<span class="{itemMetadata === undefined ? 'placeholder animate-pulse' : ''} h-6" />
+			{/if}
+			{#if item.type === 'track'}
+				<span class="{itemMetadata === undefined ? 'placeholder animate-pulse' : ''} h-6" />
+			{/if}
+		{:else}
+			{#each itemMetadata.metadataParts as metadataPart}
+				<span>{metadataPart}</span>
+			{/each}
+		{/if}
+	</svelte:fragment>
+	<svelte:fragment slot="openButton">
+		<a
+			href={item.url + '?go=1'}
+			target="_blank"
+			class="btn variant-ringed-surface font-semibold rounded-3xl"
+			class:opacity-50={$loading}
+			class:cursor-not-allowed={$loading}
+			on:click={(event) => preventDefaultIf(event, $loading)}
+		>
+			<SpotifyIcon classes="w-6 h-6 mr-3 fill-[#83D269]" />
+			Open in Spotify
+		</a>
+	</svelte:fragment>
+</ItemBase>

--- a/src/lib/components/NavMenuItem.svelte
+++ b/src/lib/components/NavMenuItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import preventDefaultIf from '$lib/helpers/preventDefaultIf';
 	import { loading } from '$lib/stores/loading';
 	import type { TransitionConfig } from 'svelte/transition';
 
@@ -14,12 +15,6 @@
 		href === $page.url.pathname
 			? '!bg-surface-900-50-token !text-surface-50-900-token hover:!bg-surface-600-300-token'
 			: '!bg-surface-100-800-token !text-surface-900-50-token hover:!bg-surface-200-700-token';
-
-	const preventDefaultIfLoading = (event: Event) => {
-		if ($loading) {
-			event.preventDefault();
-		}
-	};
 </script>
 
 <li class="!mt-0">
@@ -28,7 +23,7 @@
 		class="focus:!outline-4 focus:!outline focus:!outline-surface-500 {classesActive}"
 		class:opacity-50={$loading}
 		class:cursor-not-allowed={$loading}
-		on:click={preventDefaultIfLoading}
+		on:click={(event) => preventDefaultIf(event, $loading)}
 		transition:transition
 	>
 		<slot name="icon" />

--- a/src/lib/functions/getSpotifyMetadata.ts
+++ b/src/lib/functions/getSpotifyMetadata.ts
@@ -1,0 +1,23 @@
+import { get } from 'svelte/store';
+import { httpsCallable } from '@firebase/functions';
+import { appCheck } from '../stores/appCheck';
+import { functions } from '../stores/functions';
+import type ItemMetadata from '$lib/types/ItemMetadata';
+import type ItemType from '$lib/types/ItemType';
+
+export const getSpotifyMetadata = async (
+	itemType: ItemType,
+	prefixlessItemIds: string[]
+): Promise<ItemMetadata[]> => {
+	const $appCheck = get(appCheck);
+	const $functions = get(functions);
+	if (!$appCheck || !$functions) {
+		return [];
+	}
+
+	const getSpotifyMetadata = httpsCallable($functions, 'getSpotifyMetadata');
+
+	const result = await getSpotifyMetadata({ itemType, prefixlessItemIds });
+
+	return result.data as ItemMetadata[];
+};

--- a/src/lib/helpers/arrayChunks.ts
+++ b/src/lib/helpers/arrayChunks.ts
@@ -1,0 +1,7 @@
+const arrayChunks = <TArrayItem>(array: TArrayItem[], chunkSize: number) =>
+	Array(Math.ceil(array.length / chunkSize))
+		.fill(undefined)
+		.map((_, index) => index * chunkSize)
+		.map((begin) => array.slice(begin, begin + chunkSize));
+
+export default arrayChunks;

--- a/src/lib/helpers/getPrefixlessId.ts
+++ b/src/lib/helpers/getPrefixlessId.ts
@@ -1,0 +1,5 @@
+import type Item from '$lib/types/Item';
+
+const getPrefixlessId = (item: Item) => item.id.replace(`${item.service}:`, '');
+
+export default getPrefixlessId;

--- a/src/lib/helpers/preventDefaultIf.ts
+++ b/src/lib/helpers/preventDefaultIf.ts
@@ -1,0 +1,7 @@
+const preventDefaultIf = (event: Event, value: boolean) => {
+	if (value) {
+		event.preventDefault();
+	}
+};
+
+export default preventDefaultIf;

--- a/src/lib/stores/prefersReducedMotion.ts
+++ b/src/lib/stores/prefersReducedMotion.ts
@@ -14,7 +14,6 @@ export const prefersReducedMotion = readable(getInitialMotionPreference(), (set)
 
 	const updateMotionPreference = (event: MediaQueryListEvent) => {
 		set(event.matches);
-		console.log(event);
 	};
 
 	const mediaQueryList = window.matchMedia(reducedMotionQuery);

--- a/src/lib/stores/spotifyItemMetadata.ts
+++ b/src/lib/stores/spotifyItemMetadata.ts
@@ -1,0 +1,90 @@
+import type ItemMetadata from '$lib/types/ItemMetadata';
+
+import { derived, type Readable } from 'svelte/store';
+import type Item from '../types/Item';
+import { items } from './items';
+import { getSpotifyMetadata } from '$lib/functions/getSpotifyMetadata';
+import arrayChunks from '$lib/helpers/arrayChunks';
+import type ItemType from '$lib/types/ItemType';
+import type { AppCheck } from 'firebase/app-check';
+import type { Functions } from 'firebase/functions';
+import { appCheck } from './appCheck';
+import { functions } from './functions';
+import getPrefixlessId from '$lib/helpers/getPrefixlessId';
+
+type SpotifyItemMetadata = {
+	[itemId: string]: ItemMetadata | null;
+};
+
+export function createSpotifyItemMetadata() {
+	let loadingPrefixlessItemIds: string[] = [];
+	let spotifyItemMetadata: SpotifyItemMetadata = {};
+
+	const { subscribe } = derived<
+		[Readable<Item[]>, Readable<AppCheck>, Readable<Functions>],
+		SpotifyItemMetadata
+	>(
+		[items, appCheck, functions],
+		([$items, $appCheck, $functions], set) => {
+			if (!$items || !$items.length || !$appCheck || !$functions) {
+				return;
+			}
+
+			const itemsToLoad = $items.filter(
+				(item) =>
+					!loadingPrefixlessItemIds.includes(getPrefixlessId(item)) &&
+					spotifyItemMetadata[getPrefixlessId(item)] === undefined
+			);
+
+			const handleBatchError = (batch: string[]) => {
+				loadingPrefixlessItemIds = loadingPrefixlessItemIds.filter(
+					(loadingItemId) => !batch.includes(loadingItemId)
+				);
+
+				const batchMetadata = batch.reduce<SpotifyItemMetadata>(
+					(obj, itemId) => ({ ...obj, [itemId]: null }),
+					{}
+				);
+
+				spotifyItemMetadata = { ...spotifyItemMetadata, ...batchMetadata };
+				set(spotifyItemMetadata);
+			};
+
+			const handleBatchSuccess = (batchResult: ItemMetadata[]) => {
+				loadingPrefixlessItemIds = loadingPrefixlessItemIds.filter(
+					(loadingItemId) => !batchResult.find((batchItem) => batchItem.itemId === loadingItemId)
+				);
+
+				const batchMetadata = batchResult.reduce<SpotifyItemMetadata>(
+					(obj, item) => ({ ...obj, [item.itemId]: item }),
+					{}
+				);
+
+				spotifyItemMetadata = { ...spotifyItemMetadata, ...batchMetadata };
+				set(spotifyItemMetadata);
+			};
+
+			const fetchInBatches = (itemType: ItemType, batchSize: number) => {
+				arrayChunks(
+					itemsToLoad.filter((item) => item.type === itemType).map(getPrefixlessId),
+					batchSize
+				).forEach((batch) =>
+					getSpotifyMetadata(itemType, batch)
+						.then(handleBatchSuccess)
+						.catch(() => handleBatchError(batch))
+				);
+			};
+
+			fetchInBatches('album', 20);
+			fetchInBatches('artist', 50);
+			fetchInBatches('episode', 50);
+			fetchInBatches('podcast', 50);
+			fetchInBatches('track', 50);
+		},
+		{}
+	);
+
+	return { subscribe };
+}
+
+export const spotifyItemMetadata = createSpotifyItemMetadata();

--- a/src/lib/types/Item.d.ts
+++ b/src/lib/types/Item.d.ts
@@ -1,12 +1,12 @@
 import type ItemType from './ItemType';
+import type Service from './Service';
 
 export default interface Item {
 	id: string;
+	service: Service;
 	type: ItemType;
 	name: string;
-	metadata: string[];
-	spotifyUrl: string;
-	imageUrl: string | null;
+	url: string;
 	addedAtUtc: string;
 	listened: boolean;
 }

--- a/src/lib/types/ItemMetadata.d.ts
+++ b/src/lib/types/ItemMetadata.d.ts
@@ -1,0 +1,7 @@
+type ItemMetadata = {
+	itemId: string;
+	imageUrl: string | null;
+	metadataParts: string[];
+};
+
+export default ItemMetadata;

--- a/src/lib/types/SearchResult.d.ts
+++ b/src/lib/types/SearchResult.d.ts
@@ -3,6 +3,8 @@ import type Item from './Item';
 type SearchResult = Readonly<
 	Omit<Item, 'addedAtUtc' | 'listened'> & {
 		readonly popularity: number;
+		readonly metadata: string[];
+		readonly imageUrl: string | null;
 	}
 >;
 

--- a/src/lib/types/Service.d.ts
+++ b/src/lib/types/Service.d.ts
@@ -1,0 +1,3 @@
+type Service = 'spotify';
+
+export default Service;

--- a/src/routes/list/+page.svelte
+++ b/src/routes/list/+page.svelte
@@ -1,28 +1,15 @@
 <script lang="ts">
 	import { slide } from 'svelte/transition';
 	import { page } from '$app/stores';
-	import { goto } from '$app/navigation';
-	import {
-		Accordion,
-		AccordionItem,
-		type ModalComponent,
-		type ModalSettings,
-		modalStore,
-		SlideToggle
-	} from '@skeletonlabs/skeleton';
-	import { formatDistanceToNow } from 'date-fns';
+	import { Accordion } from '@skeletonlabs/skeleton';
 	import smoothScrollIntoViewIfNeeded from 'smooth-scroll-into-view-if-needed';
 	import { items } from '$lib/stores/items';
 	import { loading } from '$lib/stores/loading';
 	import { prefersReducedMotion } from '$lib/stores/prefersReducedMotion';
 	import Loading from '$lib/components/Loading.svelte';
 	import Plus from '$lib/components/icons/plus.svelte';
-	import TrashBin from '$lib/components/icons/trash-bin.svelte';
-	import Headphone from '$lib/components/icons/headphone.svelte';
-	import SpotifyIcon from '$lib/components/SpotifyIcon.svelte';
-	import DeleteModal from '$lib/components/DeleteModal.svelte';
-	import type Item from '$lib/types/Item';
-	import SpotifyLogo from '$lib/components/SpotifyLogo.svelte';
+	import preventDefaultIf from '$lib/helpers/preventDefaultIf';
+	import ItemSpotify from '$lib/components/ItemSpotify.svelte';
 
 	let accordionItems: { [Property: string]: HTMLDivElement } = {};
 	$: openAccordionItemId = $page.url.searchParams.get('itemId');
@@ -33,40 +20,6 @@
 			duration: 800
 		});
 	}
-
-	const onItemListenedChange = async (event: Event, item: Item) => {
-		if ($loading) {
-			event.preventDefault();
-			return;
-		}
-
-		await loading.whileAwaiting(() =>
-			items.upsertItem({
-				...item,
-				listened: (event.target as HTMLInputElement).checked
-			})
-		);
-	};
-
-	const deleteItem = (item: Item) => {
-		const modalComponent: ModalComponent = {
-			ref: DeleteModal,
-			props: { item }
-		};
-
-		const modal: ModalSettings = {
-			type: 'component',
-			component: modalComponent
-		};
-
-		modalStore.trigger(modal);
-	};
-
-	const preventDefaultIfLoading = (event: Event) => {
-		if ($loading) {
-			event.preventDefault();
-		}
-	};
 </script>
 
 {#if $items === undefined}
@@ -78,7 +31,7 @@
 		class="btn bg-surface-900-50-token text-surface-50-900-token sticky top-4 left-1/2 -translate-x-1/2 w-36"
 		class:opacity-50={$loading}
 		class:cursor-not-allowed={$loading}
-		on:click={preventDefaultIfLoading}
+		on:click={(event) => preventDefaultIf(event, $loading)}
 	>
 		<Plus />
 		<span class="sr-only">Add item</span>
@@ -99,87 +52,9 @@
 					transition:slide={{ duration: $prefersReducedMotion ? 0 : undefined }}
 					class="border-surface-900-50-token ring-4 ring-surface-900-50-token mt-1"
 				>
-					<AccordionItem
-						open={openAccordionItemId === item.id}
-						duration={$prefersReducedMotion ? 0 : undefined}
-						disabled={$loading}
-						on:toggle={(event) => {
-							goto(`/list${event.detail.open ? `?itemId=${item.id}` : ''}`, {
-								noScroll: true,
-								replaceState: true,
-								keepFocus: true
-							});
-						}}
-						regionControl="focus:-outline-offset-4"
-					>
-						<div slot="lead" class="select-none">
-							<div class="flex flex-col gap-4 shrink-0 justify-center items-center">
-								{#if item.imageUrl}
-									<img class="h-16 w-16" src={item.imageUrl} alt="" loading="lazy" />
-								{:else}
-									<div class="h-16 w-16 bg-surface-500 flex justify-center items-center">
-										<Headphone classes="h-6 w-6 text-white" />
-									</div>
-								{/if}
-								<SpotifyLogo classes="w-20" />
-							</div>
-						</div>
-						<!-- Ignoring as the click event is only handled to prevent default -->
-						<!-- svelte-ignore a11y-click-events-have-key-events -->
-						<!-- svelte-ignore a11y-no-static-element-interactions -->
-						<div
-							slot="summary"
-							class="flex flex-col select-text"
-							on:click={(event) => {
-								if (getSelection()?.toString()) {
-									event.preventDefault();
-									event.stopImmediatePropagation();
-									return;
-								}
-							}}
-						>
-							<span class="font-semibold">
-								{item.name}
-							</span>
-							{#each item.metadata as metadataPart}
-								<span>{metadataPart}</span>
-							{/each}
-						</div>
-						<div slot="content" class="flex flex-col gap-4 items-center">
-							<a
-								href={item.spotifyUrl + '?go=1'}
-								target="_blank"
-								class="btn variant-ringed-surface font-semibold rounded-3xl"
-								class:opacity-50={$loading}
-								class:cursor-not-allowed={$loading}
-								on:click={preventDefaultIfLoading}
-							>
-								<SpotifyIcon classes="w-6 h-6 mr-3 fill-[#83D269]" />
-								Open in Spotify
-							</a>
-							<SlideToggle
-								name={`listened-${item.id}`}
-								on:change={(event) => onItemListenedChange(event, item)}
-								checked={item.listened}
-								disabled={$loading}
-								class="focus:outline-offset-4"
-							>
-								Listened
-							</SlideToggle>
-							<small data-added-at-utc={item.addedAtUtc} class="text-center">
-								Added {formatDistanceToNow(new Date(item.addedAtUtc), { addSuffix: true })}
-								({new Date(item.addedAtUtc).toLocaleString()})
-							</small>
-							<button
-								class="btn-icon btn-icon-sm variant-filled-error"
-								disabled={$loading}
-								on:click={() => deleteItem(item)}
-							>
-								<TrashBin classes="w-4 h-4" />
-								<span class="sr-only">Delete {item.name}</span>
-							</button>
-						</div>
-					</AccordionItem>
+					{#if item.service === 'spotify'}
+						<ItemSpotify {item} {openAccordionItemId} />
+					{/if}
 				</div>
 			{/each}
 		</Accordion>

--- a/src/routes/list/add/+page.svelte
+++ b/src/routes/list/add/+page.svelte
@@ -43,8 +43,6 @@
 			.filter((itemType) => itemTypeFilters[itemType])
 			.join(', ');
 
-		console.log(commaSeparatedItemTypeFilters);
-
 		const lastCommaIndex = commaSeparatedItemTypeFilters.lastIndexOf(',');
 
 		if (lastCommaIndex < 0) {
@@ -135,13 +133,12 @@
 
 		const item: Item = {
 			addedAtUtc: new Date().toISOString(),
-			id: selectedItem.id,
-			imageUrl: selectedItem.imageUrl,
+			id: `${selectedItem.service}:${selectedItem.id}`,
 			listened: false,
-			metadata: selectedItem.metadata,
 			name: selectedItem.name,
-			spotifyUrl: selectedItem.spotifyUrl,
-			type: selectedItem.type
+			service: selectedItem.service,
+			type: selectedItem.type,
+			url: selectedItem.url
 		};
 
 		await loading.whileAwaiting(async () => {

--- a/src/routes/list/add/addPage.test.ts
+++ b/src/routes/list/add/addPage.test.ts
@@ -30,8 +30,9 @@ describe('add page', () => {
 				metadata: [],
 				name: 'album',
 				popularity: 0,
-				spotifyUrl: '',
-				type: 'album'
+				service: 'spotify',
+				type: 'album',
+				url: ''
 			},
 			{
 				id: 'artist',
@@ -39,8 +40,9 @@ describe('add page', () => {
 				metadata: [],
 				name: 'artist',
 				popularity: 0,
-				spotifyUrl: '',
-				type: 'artist'
+				service: 'spotify',
+				type: 'artist',
+				url: ''
 			},
 			{
 				id: 'episode',
@@ -48,8 +50,9 @@ describe('add page', () => {
 				metadata: [],
 				name: 'episode',
 				popularity: 0,
-				spotifyUrl: '',
-				type: 'episode'
+				service: 'spotify',
+				type: 'episode',
+				url: ''
 			},
 			{
 				id: 'podcast',
@@ -57,8 +60,9 @@ describe('add page', () => {
 				metadata: [],
 				name: 'podcast',
 				popularity: 0,
-				spotifyUrl: '',
-				type: 'podcast'
+				service: 'spotify',
+				type: 'podcast',
+				url: ''
 			},
 			{
 				id: 'track',
@@ -66,8 +70,9 @@ describe('add page', () => {
 				metadata: [],
 				name: 'track',
 				popularity: 0,
-				spotifyUrl: '',
-				type: 'track'
+				service: 'spotify',
+				type: 'track',
+				url: ''
 			}
 		];
 

--- a/tests/list.test.ts
+++ b/tests/list.test.ts
@@ -78,7 +78,7 @@ test.describe('list page', () => {
 		await hideEmulatorWarining(page);
 		await addButton.click();
 
-		await page.waitForURL(`/list?itemId=${id}`);
+		await page.waitForURL(`/list?itemId=spotify:${id}`);
 
 		const newItem = page.getByRole('button', { name: /^Victory Dance/ });
 		await expect(newItem).toBeVisible();
@@ -105,7 +105,7 @@ test.describe('list page', () => {
 		await hideEmulatorWarining(page);
 		await addButton.click();
 
-		await page.waitForURL(`/list?itemId=${id}`);
+		await page.waitForURL(`/list?itemId=spotify:${id}`);
 
 		const newItem = page.getByRole('button', { name: /^Victory Dance/ });
 		await expect(newItem).toBeVisible();
@@ -134,7 +134,7 @@ test.describe('list page', () => {
 		await hideEmulatorWarining(page);
 		await addButton.click();
 
-		await page.waitForURL(`/list?itemId=${id}`);
+		await page.waitForURL(`/list?itemId=spotify:${id}`);
 
 		const newItem = page.getByRole('button', { name: /^Victory Dance/ });
 		await expect(newItem).toBeVisible();
@@ -183,7 +183,7 @@ test.describe('list page', () => {
 		await hideEmulatorWarining(page);
 		await addButton.click();
 
-		await page.waitForURL(`/list?itemId=${id}`);
+		await page.waitForURL(`/list?itemId=spotify:${id}`);
 
 		const newItem = page.getByRole('button', { name: /^Victory Dance/ });
 		await expect(newItem).toBeVisible();
@@ -208,7 +208,7 @@ test.describe('list page', () => {
 
 		await addButton.click();
 
-		await page.waitForURL(`/list?itemId=${id}`);
+		await page.waitForURL(`/list?itemId=spotify:${id}`);
 
 		await expect(newItem).toHaveCount(1);
 		await expect(newItem).toBeVisible();
@@ -239,7 +239,7 @@ test.describe('list page', () => {
 		await selectOptionWithId(page, id);
 		await addButton.click();
 
-		await page.waitForURL(`/list?itemId=${id}`);
+		await page.waitForURL(`/list?itemId=spotify:${id}`);
 
 		const newItem = page.getByRole('button', { name: /^Victory Dance/ });
 		await expect(newItem).toBeVisible();
@@ -261,7 +261,7 @@ test.describe('list page', () => {
 		await hideEmulatorWarining(page);
 		await addButton.click();
 
-		await page.waitForURL(`/list?itemId=${id}`);
+		await page.waitForURL(`/list?itemId=spotify:${id}`);
 
 		const newItem = page.getByRole('button', { name: /^Victory Dance/ });
 		await expect(newItem).toBeVisible();
@@ -290,7 +290,7 @@ test.describe('list page', () => {
 		await hideEmulatorWarining(page);
 		await addButton.click();
 
-		await page.waitForURL(`/list?itemId=${id}`);
+		await page.waitForURL(`/list?itemId=spotify:${id}`);
 
 		const newItem = page.getByRole('button', { name: /^Victory Dance/ });
 		await expect(newItem).toBeVisible();
@@ -311,5 +311,33 @@ test.describe('list page', () => {
 		await expect(newItem).toBeVisible();
 		await expect(listenedSwitch).toBeVisible();
 		await expect(listenedSwitch).toBeChecked();
+	});
+
+	test('shows metadata for Spotify items', async ({ page }) => {
+		await page.goto('/list');
+		await signIn(page);
+
+		await clickAddItemButton(page);
+
+		const id = '5Nu4AvrNgIx42nWGbteHLh';
+		await fillSearchInput(page, 'Victory Dance');
+		await clickSubmitSearchButton(page);
+		await selectOptionWithId(page, id);
+
+		const addButton = await getVisibleAddButton(page);
+		await hideEmulatorWarining(page);
+		await addButton.click();
+
+		await page.waitForURL(`/list?itemId=spotify:${id}`);
+
+		const newItem = page.getByRole('button', { name: /^Victory Dance/ });
+		await expect(newItem).toBeVisible();
+		await expect(newItem).toHaveAttribute('aria-expanded', 'true');
+
+		await expect(page.getByText('Ezra Collective')).toBeVisible();
+		await expect(page.getByText("Where I'm Meant To Be")).toBeVisible();
+		await expect(
+			page.locator('img[src="https://i.scdn.co/image/ab67616d0000b273c0e7017da85ab6f7b5e1b53f"]')
+		).toBeVisible();
 	});
 });


### PR DESCRIPTION
Futureproof Item type
    - To easier allow for other services to be added in the future
    - Remove reference to Spotify: `spotifyUrl` -> `url`
    - Add `service`
    - Prefix `id` with `service`
    - Update Item to contain minimal functional data and introduce getSpotifyMetadata function (better follows Spotify developer guidelines, not storing metadata indefinitely)
    - Introduce ItemBase (with core item functionality) and ItemSpotify (using data from SpotifyMetadata store to populate ItemBase slots)
    - Refactor out `preventDefaultIfLoading` -> `preventDefaultIf` to reduce duplication